### PR TITLE
Add setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,15 @@ A simple 3D animation that simulates dozens of balls bouncing inside a rotating 
 
 ## Setup
 
-Install dependencies and start the development server:
+Run the setup script to install dependencies and verify the Node.js version:
 
 ```bash
-npm install
+./setup.sh
+```
+
+After setup, start the development server:
+
+```bash
 npm run dev
 ```
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verify that Node.js is installed and its major version is at least 18.
+if ! command -v node >/dev/null 2>&1; then
+  echo "Node.js not found. Please install Node.js 18 or newer." >&2
+  exit 1
+fi
+
+NODE_MAJOR=$(node -e 'console.log(process.versions.node.split(".")[0])')
+if [ "$NODE_MAJOR" -lt 18 ]; then
+  echo "Node.js 18 or newer is required (found $(node --version))." >&2
+  exit 1
+fi
+
+# If nvm is available, use the version from .nvmrc.
+if command -v nvm >/dev/null 2>&1 && [[ -f .nvmrc ]]; then
+  nvm install
+  nvm use
+fi
+
+# Install project dependencies.
+npm install
+
+echo "Setup complete."
+echo "To start the dev server, run: npm run dev"


### PR DESCRIPTION
## Summary
- add a `setup.sh` helper to install dependencies and verify Node.js 18+
- mention the setup script in the README

## Testing
- `./setup.sh`
- `npm run lint` *(fails: Invalid option '--config-type')*

------
https://chatgpt.com/codex/tasks/task_e_6844529cf2e4832e8bfcf402d09c6c5c